### PR TITLE
chore: explicitly set dependabot's prefix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      commit-message:
+        prefix: "chore(deps)"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      commit-message:
+        prefix: "chore(deps)"


### PR DESCRIPTION
https://github.com/NASA-IMPACT/csda-client/pull/64 doesn't follow conventional commits. I thought dependabot used conventional commits automatically, since it does on [other repos](https://github.com/developmentseed/stac-map/pull/258), but turns out it auto-detects based on the repo's history 🫠. This pr makes it explicit.