### PR TITLE
feat: add ability to inject httpx.Client

### DIFF
--- a/src/csda_client/client.py
+++ b/src/csda_client/client.py
@@ -49,36 +49,42 @@ class CsdaClient:
     """
 
     @classmethod
-    def open(cls, auth: Auth, url: str = PRODUCTION_URL) -> Self:
+    def open(
+        cls, auth: Auth, url: str = PRODUCTION_URL, httpx_client: Client | None = None
+    ) -> Self:
         """Opens and logs in a CSDA client.
 
         Args:
             auth: A [`httpx.Auth`](https://www.python-httpx.org/advanced/authentication/) that will be used for [Earthdata login](https://urs.earthdata.nasa.gov).
                 We recommend either `BasicAuth` or `NetrcAuth`.
             url: The CSDA instance to use for queries.
+            httpx_client: Optionally, inject a `httpx.Client` to use for making requests.
 
         Returns:
             A logged-in client.
         """
-        client = cls(url)
+        client = cls(url, httpx_client=httpx_client)
         client.login(auth)
         return client
 
-    def __init__(self, url: str = PRODUCTION_URL) -> None:
+    def __init__(
+        self, url: str = PRODUCTION_URL, httpx_client: Client | None = None
+    ) -> None:
         """Creates a new, un-logged-in CSDA client.
 
         Once you've created a client, use [login][csda_client.CsdaClient.login] to get an auth token.
 
         Args:
             url: The CSDA instance to use for queries.
+            httpx_client: Optionally, inject a `httpx.Client` to use for making requests.
 
         Returns:
             An un-logged-in client.
         """
-        self.client = Client()
+        self.client = httpx_client or Client()
         self.url = url
 
-    def __enter__(self) -> CsdaClient:
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
+import httpx
 import pytest
+from pydantic import SecretStr
 
 from csda_client.client import CsdaClient
 
@@ -24,3 +26,17 @@ def test_download(client: CsdaClient, tmp_path: Path) -> None:
 def test_profile(basic_auth_client: CsdaClient, earthdata_username: str) -> None:
     profile = basic_auth_client.profile(earthdata_username)
     assert profile.earthdata_username == earthdata_username
+
+
+@pytest.mark.with_earthdata_login
+def test_httpx_client_injection(
+    earthdata_username: str, earthdata_password: SecretStr
+) -> None:
+    httpx_client = httpx.Client(verify=False)
+
+    csda_client = CsdaClient(httpx_client=httpx_client)
+    assert csda_client.client is httpx_client
+
+    auth = httpx.BasicAuth(earthdata_username, earthdata_password.get_secret_value())
+    csda_client = CsdaClient.open(auth=auth, httpx_client=httpx_client)
+    assert csda_client.client is httpx_client


### PR DESCRIPTION
Closes https://github.com/NASA-IMPACT/csda-client/issues/78

This PR adds an optional `httpx_client: httpx.Client` input to the `CsdaClient` creation methods (init and `open()` helper) to facilitate using `httpx.Client` with custom setup (e.g., disabling SSL verification for local dev testing).