### PR TITLE
chore: update dependabot to use uv support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
+  - package-ecosystem: uv
     directory: "/"
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
## What I am changing

- Update dependabot to use uv support
- Contributes to: [#2328](https://github.com/NASA-IMPACT/csda-project/issues/2328#issuecomment-4443510700)
