### PR TITLE
chore: update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,27 @@
 version: 2
 updates:
   - package-ecosystem: uv
-    directory: "/"
+    directory: /
+    schedule:
+      interval: monthly
+    cooldown:
+      default-days: 15
+    groups:
+      python-dependencies:
+        patterns:
+          - "*"
     commit-message:
       prefix: "chore(deps)"
+
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "github-actions"
-    directory: "/"
+      interval: monthly
+    cooldown:
+      default-days: 15
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     commit-message:
       prefix: "chore(deps)"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
## What I am changing

- updates dependabot configuration
- contributes to https://github.com/NASA-IMPACT/csda-project/issues/2377

## How I did it

- Changed the interval of the schedule to monthly
- Group package updates broadly to streamline PRs
- Increased cooldown to 15 days
- Altered group names to reflect package ecosystem

## How you can test it

Will need to be merged in to check the configuration is working accordingly.
