### PR TITLE
feat: set user agent in csda-client

### DIFF
--- a/src/csda_client/client.py
+++ b/src/csda_client/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import contextmanager
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 from types import TracebackType
 from typing import Any, Iterator, Literal, Self
@@ -21,6 +22,13 @@ from .models import (
 )
 
 logger = logging.getLogger(__name__)
+
+try:
+    __version__ = version("csda-client")
+except PackageNotFoundError:
+    __version__ = "unknown"
+
+USER_AGENT = f"csda-client/{__version__}"
 
 Method = Literal["GET"] | Literal["POST"]
 """The HTTP methods supported by CSDA endpoints."""
@@ -82,6 +90,7 @@ class CsdaClient:
             An un-logged-in client.
         """
         self.client = httpx_client or Client()
+        self.client.headers["User-Agent"] = USER_AGENT
         self.url = url
 
     def __enter__(self) -> Self:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,7 +4,19 @@ import httpx
 import pytest
 from pydantic import SecretStr
 
-from csda_client.client import CsdaClient
+from csda_client.client import USER_AGENT, CsdaClient
+
+
+def test_default_user_agent() -> None:
+    csda_client = CsdaClient()
+    assert csda_client.client.headers["User-Agent"] == USER_AGENT
+    assert csda_client.client.headers["User-Agent"].startswith("csda-client/")
+
+
+def test_user_agent_set_on_injected_httpx_client() -> None:
+    httpx_client = httpx.Client()
+    csda_client = CsdaClient(httpx_client=httpx_client)
+    assert csda_client.client.headers["User-Agent"] == USER_AGENT
 
 
 @pytest.mark.with_earthdata_login


### PR DESCRIPTION
## Description

It'd be nice to have some breadcrumbs to indicate who is using this and for what, so this PR adds a user agent

## How I did it

- Get package version to build user agent
- Assign user agent as header (covers injected and created HTTPX clients)
- Test that user agent exists for user-injected and "client creates" HTTPX clients